### PR TITLE
Fix broken template

### DIFF
--- a/code/train/environment.yml
+++ b/code/train/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - matplotlib=3.2.2
   - numpy=1.19.0
   - pip:
-    - azureml-defaults==1.8.0
-    - azureml-dataprep[pandas,fuse]==1.9.0
+    - azureml-defaults==1.21.0
 channels:
   - conda-forge


### PR DESCRIPTION
Please merge the change to fix the broken template. The dependency `azureml-dataprep[pandas,fuse]` is no longer required with newer azureml versions.